### PR TITLE
wind22/enations: Fix warnings

### DIFF
--- a/enations_latest/src/base.h
+++ b/enations_latest/src/base.h
@@ -163,7 +163,7 @@ class CHexCoord
     friend class CSubHex;
     friend class CGameMap;  // for enumHex only!!!
   public:
-    CHexCoord( )
+    CHexCoord( ): m_iX( ), m_iY ()
     {
 #ifdef _DEBUG
         m_iX = m_iY = -1;

--- a/enations_latest/src/bmbutton.h
+++ b/enations_latest/src/bmbutton.h
@@ -111,7 +111,9 @@ class CBmButton : public CMyButton
 {
     // Construction
   public:
-    CBmButton( ) {}
+    CBmButton( ): m_iBmOn( ), m_iBtnNum( ), m_pBmBtnData( )
+    {
+    }
 
     // Attributes
   public:

--- a/enations_latest/src/building.h
+++ b/enations_latest/src/building.h
@@ -330,7 +330,7 @@ friend void CStructure::InitSprites ();
 friend void CStructure::InitLang ();
 
 public:
-			CBuildMaterials () : CStructureData (CStructureData::UTmaterials) {}
+CBuildMaterials( ): CStructureData( CStructureData::UTmaterials ), m_aiInput( ), m_aiOutput( ), m_iTime( ) {}
 
 			int			GetTime () const;
 			int			GetInput (int iInd) const;
@@ -414,7 +414,7 @@ friend void CStructure::InitSprites ();
 friend void CStructure::InitLang ();
 
 public:
-			CBuildHousing () : CStructureData (CStructureData::UThousing) {}
+CBuildHousing( ): CStructureData( CStructureData::UThousing ), m_iCapacity( ) {}
 
 			int		GetCapacity () { ASSERT_STRICT_VALID (this); return (m_iCapacity); }
 
@@ -495,7 +495,7 @@ friend void CStructure::InitSprites ();
 friend void CStructure::InitLang ();
 
 public:
-			CBuildPower () : CStructureData (CStructureData::UTpower) {}
+CBuildPower( ): CStructureData( CStructureData::UTpower ), m_iPower( ), m_iInput( ), m_iRate( ) {}
 
 			int		GetPower () { ASSERT_STRICT_VALID (this); return (m_iPower); }
 			int		GetInput () { ASSERT_STRICT_VALID (this); return (m_iInput); }
@@ -523,7 +523,7 @@ friend void CStructure::InitSprites ();
 friend void CStructure::InitLang ();
 
 public:
-			CBuildResearch () : CStructureData (CStructureData::UTresearch) {}
+CBuildResearch( ): CStructureData( CStructureData::UTresearch ), m_iRate( ) {}
 
 			int		GetRate () { ASSERT_STRICT_VALID (this); return (m_iRate); }
 
@@ -619,14 +619,14 @@ friend void CStructure::InitSprites ();
 friend void CStructure::InitLang ();
 
 public:
-			CBuildMine () : CStructureData (CStructureData::UTmine) {}
+CBuildMine( ): CStructureData( CStructureData::UTmine ), m_iTime( ), m_iAmount( ), m_iOutput( ) {}
 
 			int				GetTimeToMine () const { return (m_iTime); }
 			int				GetAmount () const { return (m_iAmount); }
 			int				GetTypeMines () const { return (m_iOutput); }
 
 protected:
-			int			m_iTime;								// time to mine
+			int			m_iTime;							// time to mine
 			int			m_iAmount;							// amount produced in MAX_DENSITY ground
 			int			m_iOutput;							// CMaterialTypes:: it mines
 
@@ -647,9 +647,9 @@ friend void CStructure::InitSprites ();
 friend void CStructure::InitLang ();
 
 public:
-			CBuildFarm () : CStructureData (CStructureData::UTfarm) {}
+CBuildFarm( ): CStructureData( CStructureData::UTfarm ), m_iTime( ), m_iOutput( ), m_iQuantity( ) {}
 
-			void			BuildFarm ();
+			void			BuildFarm (); // apparently unused and unimplemented
 
 			int				GetTimeToFarm () const { return (m_iTime); }
 			int				GetTypeFarm () const { return (m_iOutput); }
@@ -658,7 +658,7 @@ public:
 static int			GetCowDistance () { return (3); }
 
 protected:
-			int			m_iTime;								// time to mine
+			int			m_iTime;							// time to mine
 			int			m_iOutput;							// CMaterialTypes:: it mines
 			int			m_iQuantity;						// how much you get each time
 

--- a/enations_latest/src/caidata.cpp
+++ b/enations_latest/src/caidata.cpp
@@ -903,7 +903,7 @@ void CAIData::SetWorldSize( int iHexPerBlk, int iBlkPerSide )
 //
 // create
 //
-CAIData::CAIData( int iSmart, int iNumAi, int iNumHuman )
+CAIData::CAIData( int iSmart, int iNumAi, int iNumHuman ): m_iBlkPerSide( ), m_iHexPerBlk( )
 {
     m_iStartPos      = 0;  // safe default
     m_iSmart         = iSmart;

--- a/enations_latest/src/caidata.cpp
+++ b/enations_latest/src/caidata.cpp
@@ -666,7 +666,7 @@ void CAIData::BuildAt( CHexCoord& hexSite, int iBldg, int iDir, CAIUnit* paiUnit
         // BUGBUG check the vehicle's location and make
         // sure it matches with the hexSite sent in msg
         CHexCoord hexVeh = pVehicle->GetHexHead( );
-#ifdef _DEBUG || STRICTER_ASSERTS
+#if defined(_DEBUG) || STRICTER_ASSERTS
         ASSERT( hexVeh == hexSite );
 #endif
         if ( hexVeh != hexSite )

--- a/enations_latest/src/caiunit.hpp
+++ b/enations_latest/src/caiunit.hpp
@@ -73,7 +73,9 @@ protected:
 public:
 	CAIUnit( DWORD dwID, int iOwner, int iType, int iTypeUnit );
 	~CAIUnit();
-	CAIUnit() {};
+    CAIUnit( )
+        : m_bControl( ), m_dwData( ), m_dwID( ), m_iOwner( ), m_iType( ), m_iTypeUnit( ), m_pdwaParams( ),
+          m_pwaParams( ), m_plCopyData( ), m_timeLastDest( ), m_wGoal( ), m_wStatus( ), m_wTask( ) {};
 
 	DWORD GetID( void );
 	void SetID( DWORD );

--- a/enations_latest/src/credits.h
+++ b/enations_latest/src/credits.h
@@ -20,13 +20,13 @@
 class CCreditLine
 {
 public:
-		CCreditLine () {}
+    CCreditLine( ): m_iAlign( ), m_iSize( ), m_iRtn( ) {}
 		~CCreditLine () {}
 
 	int				m_iAlign;		// 0 == left, 1 == center, 2 == right
 	int				m_iSize;		// m_font[]
 	int				m_iRtn;			// TRUE -> CR at end of line
-	CString		m_sText;		// guess
+	CString		    m_sText;		// guess
 };
 
 

--- a/enations_latest/src/cutscene.h
+++ b/enations_latest/src/cutscene.h
@@ -48,7 +48,7 @@ class CWndCutScene : public CWndBase
 {
 // Construction
 public:
-	CWndCutScene () { m_pdibPicture = NULL; }
+CWndCutScene( ): m_iTyp( ), m_iRtn( ), m_iScenario( ), m_bTile( ) { m_pdibPicture = NULL; }
 
 	void		Create (int iTyp, int iScenario = -1);
 				enum { cut, repeat, scenario_end, win, lose };

--- a/enations_latest/src/ipcmsg.hpp
+++ b/enations_latest/src/ipcmsg.hpp
@@ -85,7 +85,7 @@ public:
 	CString m_sMessage;		// body of message
 	CWnd *m_pOpenWnd;		// pointer to open window for this type
 
-	CEMsg() {};
+	CEMsg( ): m_iID( ), m_iFrom( ), m_iTo( ), m_iCC( ), m_wStatus( ), m_pOpenWnd( ) {};
 	~CEMsg();
 
 	CEMsg( int iID, int iFrom, int iTo, 
@@ -99,9 +99,9 @@ class CEMsgList : public CObList
 	DECLARE_SERIAL( CEMsgList );
 
 public:
-	int m_iLastID;	// last id used
+    int m_iLastID;  // last id used
 
-	CEMsgList() {};
+	CEMsgList( ): m_iLastID( ) {};
 	~CEMsgList();
 
 	CEMsg *GetNextPrevMsg( int iID, int iCmd );

--- a/enations_latest/src/lastplnt.cpp
+++ b/enations_latest/src/lastplnt.cpp
@@ -131,7 +131,7 @@ void CatchNum( int iNum )
         return;
 
     CString sMsg;
-    sMsg.LoadString( IDS_ERR_LOAD_1 );
+    (void)sMsg.LoadString( IDS_ERR_LOAD_1 );
     char sNum[20];
     if ( iNum >= ERR_BASE_USER_ERROR )
         iNum -= ERR_BASE_USER_ERROR;
@@ -157,16 +157,16 @@ void CatchSE( SE_Exception e )
 
     CDlgStackDump dlg;
     dlg.m_pe = &e;
-    dlg.m_sText.LoadString( IDS_ERR_LOAD_3 );
+    (void)dlg.m_sText.LoadString( IDS_ERR_LOAD_3 );
 
     MEMORYSTATUS ms {};
     ms.dwLength = sizeof( ms );
-    GlobalMemoryStatus( &ms );
+    GlobalMemoryStatus( &ms ); // TODO: replace with GlobalMemoryStatusEx
     const int ONE_MEG = 1024 * 1024;
     if ( ms.dwAvailPageFile / ONE_MEG < 8 )
     {
         CString sMsg {};
-        sMsg.LoadString( IDS_OUT_OF_MEMORY );
+        (void)sMsg.LoadString( IDS_OUT_OF_MEMORY );
         dlg.m_sText = sMsg + "\r\n" + dlg.m_sText;
     }
 
@@ -217,7 +217,7 @@ void CatchOther( )
     theGame.EmptyQueue( );
 
     CString sMsg;
-    sMsg.LoadString( IDS_ERR_LOAD_2 );
+    (void)sMsg.LoadString( IDS_ERR_LOAD_2 );
     AfxMessageBox( sMsg, MB_OK | MB_ICONSTOP );
 
     bDoSubclass = TRUE;
@@ -398,7 +398,7 @@ BOOL CConquerApp::InitInstance( )
 
     InitWindwardLib1( this );
 
-    
+
 
 
     WriteProfileString( "ADPCM", "Error", "OK" );
@@ -443,7 +443,7 @@ BOOL CConquerApp::InitInstance( )
     InitializeCriticalSection( &cs );
     hRenderEvent = CreateEvent( NULL, TRUE, FALSE, "RenderEvent" );
 
-    m_sAppName.LoadString( IDS_MAIN_TITLE );
+    (void)m_sAppName.LoadString( IDS_MAIN_TITLE );
 
     // Get CPU Speed
     CPUInfo cpu;
@@ -512,7 +512,7 @@ BOOL CConquerApp::InitInstance( )
             {
                 CDlgMsg dlg;
                 CString sMsg;
-                sMsg.LoadString( IDS_KILLER_RES );
+                (void)sMsg.LoadString( IDS_KILLER_RES );
                 CString sRes = IntToCString( m_iOldWidth ) + "x" + IntToCString( m_iOldHeight ) + "x" +
                                IntToCString( m_iOldDepth );
                 csPrintf( &sMsg, (char const*)sRes, pRes );
@@ -636,7 +636,7 @@ BOOL CConquerApp::InitInstance( )
     OSVERSIONINFO ovi;
     memset( &ovi, 0, sizeof( ovi ) );
     ovi.dwOSVersionInfoSize = sizeof( ovi );
-    GetVersionEx( &ovi );
+    GetVersionEx( &ovi ); // TODO: Consider using VerifyVersionInfo* or IsWindows*
     m_sOs += " " + LongToCString( ovi.dwMajorVersion ) + "." + LongToCString( ovi.dwMinorVersion ) + " (";
     if ( ( ovi.dwBuildNumber & 0xFFFF0000 ) == 0 )
         m_sOs += LongToCString( ovi.dwBuildNumber ) + ")";
@@ -651,17 +651,17 @@ BOOL CConquerApp::InitInstance( )
 
     long lVer = CNetApi::GetVersion( );
     m_sNet    = "VDMPlay API " + IntToCString( HIBYTE( HIWORD( lVer ) ) ) + "." +
-             IntToCString( LOBYTE( HIWORD( lVer ) ) ) + "." + IntToCString( LOWORD( lVer ) );
+                IntToCString( LOBYTE( HIWORD( lVer ) ) ) + "." + IntToCString( LOWORD( lVer ) );
     Log( m_sNet );
 
     MEMORYSTATUS ms {};
     ms.dwLength = sizeof( ms );
-    GlobalMemoryStatus( &ms );
-    const int ONE_MEG   = 1024 * 1024;
-    CString sMemory = "Memory (avail/total) Physical: " + IntToCString( ms.dwAvailPhys / ONE_MEG ) + "M/" +
-                      IntToCString( ms.dwTotalPhys / ONE_MEG ) +
-                      "M Virtual: " + IntToCString( ms.dwAvailPageFile / ONE_MEG ) + "M/" +
-                      IntToCString( ms.dwTotalPageFile / ONE_MEG ) + "M";
+    GlobalMemoryStatus( &ms ); // TODO: replace with GlobalMemoryStatusEx
+    const int ONE_MEG = 1024 * 1024;
+    CString   sMemory = "Memory (avail/total) Physical: " + IntToCString( ms.dwAvailPhys / ONE_MEG ) + "M/" +
+                        IntToCString( ms.dwTotalPhys / ONE_MEG ) +
+                        "M Virtual: " + IntToCString( ms.dwAvailPageFile / ONE_MEG ) + "M/" +
+                        IntToCString( ms.dwTotalPageFile / ONE_MEG ) + "M";
     Log( sMemory );
 
     // enough memory?
@@ -678,7 +678,7 @@ BOOL CConquerApp::InitInstance( )
     if ( ms.dwTotalPageFile < 1024 * 1024 * MEM_NEEDED_BASE )
     {
         CString sText;
-        sText.LoadString( IDS_ERROR_LOW_VIRT_MEM );
+        (void)sText.LoadString( IDS_ERROR_LOW_VIRT_MEM );
         CString sNum;
         sNum = IntToCString( MEM_NEEDED_BASE );
         csPrintf( &sText, (char const*)sNum );
@@ -851,7 +851,7 @@ BOOL CConquerApp::InitInstance( )
         m_bShareware  = pMmio->ReadShort( );
         m_bSecondDisk = pMmio->ReadShort( );
         m_bWAV        = pMmio->ReadShort( );
-        m_iRequireCD  = FALSE; // pMmio->ReadShort( ); // no longer needs CD!
+        m_iRequireCD  = FALSE;  // pMmio->ReadShort( ); // no longer needs CD!
         m_iMultVoices = pMmio->ReadShort( );
         m_iHaveIntro  = pMmio->ReadShort( );
 
@@ -885,7 +885,7 @@ BOOL CConquerApp::InitInstance( )
         {
             TRAP( );
             CString sMsg, sNum1, sNum2;
-            sMsg.LoadString( IDS_WRONG_DATA_FILE );
+            (void)sMsg.LoadString( IDS_WRONG_DATA_FILE );
             sNum1 = IntToCString( m_iRifVer );
             sNum2 = IntToCString( VER_RIFF );
             csPrintf( &sMsg, (char const*)sName, (char const*)sNum1, (char const*)sNum2 );
@@ -961,18 +961,18 @@ BOOL CConquerApp::InitInstance( )
             else
                 // is it earlier (ie did they advance the date before installing)?
                 if ( iToday < (int)dwTime )
-            {
-                iToday -= i1Month / 2;
-                RegSetValueEx( key, "CD-ROM", NULL, REG_DWORD, (unsigned char*)&iToday, sizeof( iToday ) );
-            }
-            else if ( iToday > (int)dwTime + i1Month )
-            {
-                CTime   _time( dwTime );
-                CString sBuf = _time.Format( "Installed: %x" );
-                Log( sBuf );
-                AfxMessageBox( IDS_DEMO_OVER, MB_OK | MB_ICONSTOP );
-                return ( 0 );
-            }
+                {
+                    iToday -= i1Month / 2;
+                    RegSetValueEx( key, "CD-ROM", NULL, REG_DWORD, (unsigned char*)&iToday, sizeof( iToday ) );
+                }
+                else if ( iToday > (int)dwTime + i1Month )
+                {
+                    CTime   _time( dwTime );
+                    CString sBuf = _time.Format( "Installed: %x" );
+                    Log( sBuf );
+                    AfxMessageBox( IDS_DEMO_OVER, MB_OK | MB_ICONSTOP );
+                    return ( 0 );
+                }
 
             RegCloseKey( key );
         }
@@ -990,29 +990,29 @@ BOOL CConquerApp::InitInstance( )
             else
                 // is it earlier (ie did they advance the date before installing)?
                 if ( iToday < (int)iTime )
-            {
-                iToday -= i1Month / 2;
-                char sBuf[20];
-                itoa( iToday + i1Month, sBuf, 10 );
-                ::WriteProfileString( "DOS Emulation", "_COMM", sBuf );
-            }
-            else if ( iToday > (int)iTime + i1Month )
-            {
-                TRAP( );
-                CTime   _time( iTime );
-                CString sBuf = _time.Format( "Installed: %x" );
-                Log( sBuf );
-                AfxMessageBox( IDS_DEMO_OVER, MB_OK | MB_ICONSTOP );
-                return ( 0 );
-            }
+                {
+                    iToday -= i1Month / 2;
+                    char sBuf[20];
+                    itoa( iToday + i1Month, sBuf, 10 );
+                    ::WriteProfileString( "DOS Emulation", "_COMM", sBuf );
+                }
+                else if ( iToday > (int)iTime + i1Month )
+                {
+                    TRAP( );
+                    CTime   _time( iTime );
+                    CString sBuf = _time.Format( "Installed: %x" );
+                    Log( sBuf );
+                    AfxMessageBox( IDS_DEMO_OVER, MB_OK | MB_ICONSTOP );
+                    return ( 0 );
+                }
         }
     }
 
-    Log( "Check for CD" );
+    //Log( "Check for CD" );
 
     // do we have a CD?
-    if ( !CheckForCD( ) )
-        return ( 0 );
+    //if ( !CheckForCD( ) )
+    //    return ( 0 );
 
     // shareware notice
     if ( IsShareware( ) )
@@ -1022,7 +1022,7 @@ BOOL CConquerApp::InitInstance( )
         if ( ( iTry % 25 ) == 0 )
         {
             CString sMsg;
-            sMsg.LoadString( IDS_DEMO_25 );
+            (void)sMsg.LoadString( IDS_DEMO_25 );
             CString sNum = IntToCString( iTry );
             csPrintf( &sMsg, (char const*)sNum );
             if ( AfxMessageBox( sMsg, MB_YESNO | MB_ICONSTOP ) != IDYES )
@@ -1068,7 +1068,7 @@ BOOL CConquerApp::InitInstance( )
 
         // RedText class for -#s in dialogs
 //        if ( m_hPrevInstance == NULL )  // If statement removed because hPrevInstance is always null in modern windows
-//        {
+        //        {
         WNDCLASS wc;
         memset( &wc, 0, sizeof( wc ) );
         wc.lpfnWndProc   = RedTextProc;
@@ -1084,7 +1084,7 @@ BOOL CConquerApp::InitInstance( )
         if ( !RegisterClass( &wc ) )
             return ( FALSE );
         Log( "Window classes registered" );
-//        }
+        //        }
 
 #ifdef _CHEAT
         _bShowRate       = GetProfileInt( "Debug", "ShowRate", 0 );
@@ -1255,7 +1255,7 @@ BOOL CConquerApp::InitInstance( )
 
             delete pMmio;
 
-// time the CD // we dont have a cd anymore
+            // time the CD // we dont have a cd anymore
             m_iCdSpeed = 100; // assume fast CD drive
 #if !defined(_GG) && 0
             if ( ( m_iCdSpeed = GetProfileInt( "Advanced", "CDspeed", 0 ) ) <= 0 )
@@ -1369,7 +1369,7 @@ BOOL CConquerApp::InitInstance( )
             try
             {
                 m_wndMovie.AddMovie( "logo.avi" );
-//                m_wndMovie.AddMovie( "headgame.avi" );  // This file doesnt exist
+                //                m_wndMovie.AddMovie( "headgame.avi" );  // This file doesnt exist
                 m_wndMovie.AddMovie( "intro.avi" );
                 m_wndMovie.Create( FALSE );
             }
@@ -1621,7 +1621,7 @@ void CConquerApp::CreateMain( )
         m_wndMovie.DestroyWindow( );
 
     // if coming from a game setup - kill it
-    theGame.SetShouldProcessMessages(FALSE);
+    theGame.SetShouldProcessMessages( FALSE );
     DestroyExceptMain( );
 
     m_wndMain.SetProgPos( CWndMain::playing );
@@ -1638,7 +1638,7 @@ void CConquerApp::CreateMain( )
     m_pdlgMain->ShowWindow( SW_SHOW );
     theGame.SetState( CGame::main );
 
-    CheckForCD( );
+    // CheckForCD( );
 
     theMusicPlayer.PlayExclusiveMusic( MUSIC::GetID( MUSIC::main_screen ) );
 }
@@ -1747,7 +1747,7 @@ int CConquerApp::ExitInstance( )
         dc.SetBkMode( TRANSPARENT );
         dc.SetTextColor( RGB( 0, 0, 0 ) );
         CString sLoad;
-        sLoad.LoadString( IDS_LEAVING );
+        (void)sLoad.LoadString( IDS_LEAVING );
         dc.TextOut( 0, 0, sLoad );
     }
 
@@ -1757,7 +1757,7 @@ int CConquerApp::ExitInstance( )
     CloseHandle( hRenderEvent );
 
 #ifdef USE_SMARTHEAP
- //   MemUnregisterTask( );
+    //   MemUnregisterTask( );
 #endif
 
     if ( m_hLibLang != NULL )
@@ -2094,7 +2094,7 @@ BOOL CDlgMain::OnInitDialog( )
 
     SendMessage( WM_SETICON, (WPARAM)TRUE, (LPARAM)theApp.LoadIcon( MAKEINTRESOURCE( IDI_MAIN ) ) );
     CString sTitle;
-    sTitle.LoadString( IDS_MAIN_TITLE );
+    (void)sTitle.LoadString( IDS_MAIN_TITLE );
     SetWindowText( sTitle );
 
     // if shareware no loading
@@ -2150,14 +2150,14 @@ void CDlgMain::OnSize( UINT nType, int cx, int cy )
     {
         // probably not an issue!
 #ifdef LOGGINGON
-     //   OutputDebugStringA( "not init'ed yet\n" );
+        //   OutputDebugStringA( "not init'ed yet\n" );
 #endif
         return;
     }
-    else 
+    else
     {
 #ifdef LOGGINGON
-     //   OutputDebugStringA( "OnSize a go!\n" );
+        //   OutputDebugStringA( "OnSize a go!\n" );
 #endif
     }
 
@@ -2295,7 +2295,7 @@ void CDlgMain::OnPaint( )
 
     // put up the title
     CString sTitle;
-    sTitle.LoadString( IDS_MAIN_TITLE );
+    (void)sTitle.LoadString( IDS_MAIN_TITLE );
     LOGFONT lf;
     memset( &lf, 0, sizeof( lf ) );
     lf.lfWidth  = ( 3 * ( iWid / sTitle.GetLength( ) ) ) / 4;
@@ -2339,7 +2339,7 @@ void CDlgMain::OnPaint( )
 
     // put up copyright
     CString sCopy;
-    sCopy.LoadString( IDS_COPYRIGHT );
+    (void)sCopy.LoadString( IDS_COPYRIGHT );
     GetClientRect( &rect );
     dc.DrawText( sCopy, -1, &rect, DT_CALCRECT | DT_CENTER | DT_SINGLELINE | DT_TOP );
     int iHt     = rect.Height( );
@@ -2771,7 +2771,7 @@ CDlgVer::CDlgVer( CWnd* pParent /*=NULL*/ ): CDialog( CDlgVer::IDD, pParent )
     OSVERSIONINFO ovi;
     memset( &ovi, 0, sizeof( ovi ) );
     ovi.dwOSVersionInfoSize = sizeof( ovi );
-    if ( GetVersionEx( &ovi ) )
+    if ( GetVersionEx( &ovi ) ) // TODO: consider VerifyVersionInfo* or IsWindows* instead.
         m_sOs += " " + LongToCString( ovi.dwMajorVersion ) + "." + LongToCString( ovi.dwMinorVersion ) + " (" +
                  LongToCString( ovi.dwBuildNumber ) + ")";
     if ( iWinType == W32s )
@@ -2782,7 +2782,7 @@ CDlgVer::CDlgVer( CWnd* pParent /*=NULL*/ ): CDialog( CDlgVer::IDD, pParent )
 
     long lVer = CNetApi::GetVersion( );
     m_sNet    = "VDMPlay API " + IntToCString( HIBYTE( HIWORD( lVer ) ) ) + "." +
-             IntToCString( LOBYTE( HIWORD( lVer ) ) ) + "." + IntToCString( LOWORD( lVer ) );
+                IntToCString( LOBYTE( HIWORD( lVer ) ) ) + "." + IntToCString( LOWORD( lVer ) );
 
     m_sRif = "Data Ver: " + IntToCString( theApp.GetRifVer( ) ) + "." + IntToCString( VER_RIFF );
     if ( theApp.IsShareware( ) )
@@ -2896,12 +2896,12 @@ CDlgVer::CDlgVer( CWnd* pParent /*=NULL*/ ): CDialog( CDlgVer::IDD, pParent )
 
     MEMORYSTATUS ms {};
     ms.dwLength = sizeof( ms );
-    GlobalMemoryStatus( &ms );
+    GlobalMemoryStatus( &ms ); // TODO: replace with GlobalMemoryStatusEx
     const int ONE_MEG = 1024 * 1024;
     m_sMemory         = "Memory (avail/total) Physical: " + IntToCString( ms.dwAvailPhys / ONE_MEG ) + "M/" +
-                IntToCString( ms.dwTotalPhys / ONE_MEG ) +
-                "M Virtual: " + IntToCString( ms.dwAvailPageFile / ONE_MEG ) + "M/" +
-                IntToCString( ms.dwTotalPageFile / ONE_MEG ) + "M";
+                        IntToCString( ms.dwTotalPhys / ONE_MEG ) +
+                        "M Virtual: " + IntToCString( ms.dwAvailPageFile / ONE_MEG ) + "M/" +
+                        IntToCString( ms.dwTotalPageFile / ONE_MEG ) + "M";
 
     if ( iWinType == W32s )
     {
@@ -3000,7 +3000,7 @@ void CDlgStackDump::OnCopyStack( )
 
     MEMORYSTATUS ms {};
     ms.dwLength = sizeof( ms );
-    GlobalMemoryStatus( &ms );
+    GlobalMemoryStatus( &ms ); // TODO: replace with GlobalMemoryStatusEx
     const int ONE_MEG = 1024 * 1024;
 
     char sNum1[20], sNum2[20];
@@ -3009,7 +3009,7 @@ void CDlgStackDump::OnCopyStack( )
     CString sMsg;
     if ( ms.dwAvailPageFile / ONE_MEG < 8 )
     {
-        sMsg.LoadString( IDS_OUT_OF_MEMORY );
+        (void)sMsg.LoadString( IDS_OUT_OF_MEMORY );
         sMsg += "\r\n";
     }
     sMsg += "Sorry, an unknown error occured.\r\nVersion: " + CString( VER_STRING ) + "\r\n" +

--- a/enations_latest/src/lastplnt.cpp
+++ b/enations_latest/src/lastplnt.cpp
@@ -159,18 +159,18 @@ void CatchSE( SE_Exception e )
     dlg.m_pe = &e;
     dlg.m_sText.LoadString( IDS_ERR_LOAD_3 );
 
-    MEMORYSTATUS ms;
+    MEMORYSTATUS ms {};
     ms.dwLength = sizeof( ms );
     GlobalMemoryStatus( &ms );
     const int ONE_MEG = 1024 * 1024;
     if ( ms.dwAvailPageFile / ONE_MEG < 8 )
     {
-        CString sMsg;
+        CString sMsg {};
         sMsg.LoadString( IDS_OUT_OF_MEMORY );
         dlg.m_sText = sMsg + "\r\n" + dlg.m_sText;
     }
 
-    char sNum1[20], sNum2[80], sNumS[5][20];
+    char sNum1[20] {}, sNum2[80] {}, sNumS[5][20] {};
     itoa( e.m_uEc, sNum1, 16 );
     switch ( (uint64_t)e.m_pExCode )
     {
@@ -654,7 +654,7 @@ BOOL CConquerApp::InitInstance( )
              IntToCString( LOBYTE( HIWORD( lVer ) ) ) + "." + IntToCString( LOWORD( lVer ) );
     Log( m_sNet );
 
-    MEMORYSTATUS ms;
+    MEMORYSTATUS ms {};
     ms.dwLength = sizeof( ms );
     GlobalMemoryStatus( &ms );
     const int ONE_MEG   = 1024 * 1024;
@@ -935,8 +935,8 @@ BOOL CConquerApp::InitInstance( )
             RegSetValueEx( key, NULL, NULL, REG_SZ, (unsigned char*)"4", 2 );
 
             unsigned long iLen = 256;
-            DWORD         dwTyp, dwLen = sizeof( DWORD );
-            time_t        dwTime;
+            DWORD         dwTyp {}, dwLen = sizeof( DWORD );
+            time_t        dwTime {};
             if ( RegQueryValueEx( key, "CD-ROM", NULL, &dwTyp, (unsigned char*)&dwTime, &dwLen ) != ERROR_SUCCESS )
             {
                 TRAP( );
@@ -1489,8 +1489,8 @@ BOOL CConquerApp::InitInstance( )
         m_sSoundVer = "MSS: " + CString( theMusicPlayer.GetVersion( ) ) + " {off}";
     else
     {
-        char sBuf[130], *psFmt;
-        long iRate, iFmt;
+        char sBuf[130] {}, *psFmt {};
+        long iRate {}, iFmt {};
         sBuf[0] = 0;
         AIL_digital_configuration( theMusicPlayer._GetHDig( ), &iRate, &iFmt, sBuf );
         switch ( iFmt )
@@ -2868,8 +2868,8 @@ CDlgVer::CDlgVer( CWnd* pParent /*=NULL*/ ): CDialog( CDlgVer::IDD, pParent )
         m_sSoundVer = "MSS: " + CString( theMusicPlayer.GetVersion( ) ) + " {off}";
     else
     {
-        char sBuf[130], *psFmt;
-        long iRate, iFmt;
+        char sBuf[130] {}, *psFmt {};
+        long iRate {}, iFmt {};
         sBuf[0] = 0;
         AIL_digital_configuration( theMusicPlayer._GetHDig( ), &iRate, &iFmt, sBuf );
         switch ( iFmt )
@@ -2894,7 +2894,7 @@ CDlgVer::CDlgVer( CWnd* pParent /*=NULL*/ ): CDialog( CDlgVer::IDD, pParent )
     m_sSpeed = "CPU Speed: ~" + IntToCString( theApp.GetCpuSpeed( ) ) + "  CD-ROM Speed: ~" +
                IntToCString( theApp.GetCdSpeed( ) ) + "X";
 
-    MEMORYSTATUS ms;
+    MEMORYSTATUS ms {};
     ms.dwLength = sizeof( ms );
     GlobalMemoryStatus( &ms );
     const int ONE_MEG = 1024 * 1024;
@@ -2998,7 +2998,7 @@ void CDlgStackDump::OnCopyStack( )
         return;
     }
 
-    MEMORYSTATUS ms;
+    MEMORYSTATUS ms {};
     ms.dwLength = sizeof( ms );
     GlobalMemoryStatus( &ms );
     const int ONE_MEG = 1024 * 1024;

--- a/enations_latest/src/lastplnt.cpp
+++ b/enations_latest/src/lastplnt.cpp
@@ -1257,7 +1257,7 @@ BOOL CConquerApp::InitInstance( )
 
 // time the CD // we dont have a cd anymore
             m_iCdSpeed = 100; // assume fast CD drive
-#ifndef _GG && 0
+#if !defined(_GG) && 0
             if ( ( m_iCdSpeed = GetProfileInt( "Advanced", "CDspeed", 0 ) ) <= 0 )
             {
                 CFile* pFile = theDataFile.OpenAsFile( "music" );

--- a/enations_latest/src/netcmd.h
+++ b/enations_latest/src/netcmd.h
@@ -157,8 +157,8 @@ class CNetCmd : public VPMsgHdr
         last_message  // used for ASSERT
     };
 
-    CNetCmd( ) { m_bMsg = (BYTE)-1; }
-    CNetCmd( int iCmd ) { m_bMsg = (BYTE)iCmd; }
+    CNetCmd( ): m_bMemPool( ) { m_bMsg = (BYTE)-1; }
+    CNetCmd( int iCmd ): m_bMemPool( ) { m_bMsg = (BYTE)iCmd; }
 
     int GetType( ) const { return ( m_bMsg ); }
 
@@ -200,7 +200,11 @@ class CNetReady : public CNetCmd
 class CNetPlyrJoin : public CNetCmd
 {
   public:
-    CNetPlyrJoin( ): CNetCmd( cmd_plyr_join ) {}
+    CNetPlyrJoin( )
+        : CNetCmd( cmd_plyr_join ), m_iLen( ), m_iPlyrNum( ), m_iPwrHave( ), m_iPwrNeed( ), m_iPplHave( ),
+          m_iPplNeed( ), m_iMat( ), m_iRsrchLevel( ), m_iNumBldgs( ), m_iNumVeh( ), m_bAvail( ), m_sName( )
+    {
+    }
 
     static CNetPlyrJoin* Alloc( const CNetPlyrJoin* pData );
     static CNetPlyrJoin* Alloc( const CPlayer* pPlyr );
@@ -437,8 +441,8 @@ class _CMsgBldg : public CNetCmd
 class _CMsgRoad : public CNetCmd
 {
   public:
-    _CMsgRoad( ): CNetCmd( -1 ) {}
-    _CMsgRoad( int iMsg ): CNetCmd( iMsg ) {}
+    _CMsgRoad( ): CNetCmd( -1 ), m_iPlyrNum( ), m_dwID( ), m_hexBuild( ), m_iMode( ) {}
+    _CMsgRoad( int iMsg ): CNetCmd( iMsg ), m_iPlyrNum( ), m_dwID( ), m_hexBuild( ), m_iMode( ) {}
 
     int       m_iPlyrNum;  // player requesting the placement
     DWORD     m_dwID;      // ID of vehicle
@@ -461,8 +465,14 @@ class _CMsgRoad : public CNetCmd
 class _CMsgBridge : public CNetCmd
 {
   public:
-    _CMsgBridge( ): CNetCmd( -1 ) {}
-    _CMsgBridge( int iMsg ): CNetCmd( iMsg ) {}
+    _CMsgBridge( )
+        : CNetCmd( -1 ), m_dwIDBrdg( ), m_iPlyrNum( ), m_dwIDVeh( ), m_hexStart( ), m_hexEnd( ), m_iAlt( ), m_iMode( )
+    {
+    }
+    _CMsgBridge( int iMsg )
+        : CNetCmd( iMsg ), m_dwIDBrdg( ), m_iPlyrNum( ), m_dwIDVeh( ), m_hexStart( ), m_hexEnd( ), m_iAlt( ), m_iMode( )
+    {
+    }
 
     DWORD     m_dwIDBrdg;  // ID of bridge
     int       m_iPlyrNum;  // player requesting the placement
@@ -486,8 +496,18 @@ class _CMsgBridge : public CNetCmd
 class _CMsgVehGo : public CNetCmd
 {
   public:
-    _CMsgVehGo( ): CNetCmd( -1 ) {}
-    _CMsgVehGo( int iMsg ): CNetCmd( iMsg ) {}
+    _CMsgVehGo( )
+        : CNetCmd( -1 ), m_dwID( ), m_iPlyrNum( ), m_ptDest( ), m_ptNext( ), m_ptHead( ), m_ptTail( ), m_hexNext( ),
+          m_hexDest( ), m_iDir( ), m_iTurretDir( ), m_iXadd( ), m_iYadd( ), m_iDadd( ), m_iTadd( ), m_iMode( ),
+          m_iOwn( ), m_iStepsLeft( ), m_iSpeed( ), m_dwBlocker( ), m_bOnWater( )
+    {
+    }
+    _CMsgVehGo( int iMsg )
+        : CNetCmd( iMsg ), m_dwID( ), m_iPlyrNum( ), m_ptDest( ), m_ptNext( ), m_ptHead( ), m_ptTail( ), m_hexNext( ),
+          m_hexDest( ), m_iDir( ), m_iTurretDir( ), m_iXadd( ), m_iYadd( ), m_iDadd( ), m_iTadd( ), m_iMode( ),
+          m_iOwn( ), m_iStepsLeft( ), m_iSpeed( ), m_dwBlocker( ), m_bOnWater( )
+    {
+    }
     const _CMsgVehGo operator=( _CMsgVehGo const& src );
 
     DWORD     m_dwID;        // ID of vehicle
@@ -520,7 +540,11 @@ class _CMsgVehGo : public CNetCmd
 class CMsgUnitDamage : public CNetCmd
 {
   public:
-    CMsgUnitDamage( ): CNetCmd( unit_damage ) {}
+    CMsgUnitDamage( )
+        : CNetCmd( unit_damage ), m_dwIDTarget( ), m_iPlyrTarget( ), m_dwIDDamage( ), m_iPlyrDamage( ), m_dwIDShoot( ),
+          m_iPlyrShoot( ), m_iDamageShot( )
+    {
+    }
     CMsgUnitDamage( CUnit const* pTarget, CUnit const* pShoot, CUnit const* pDamage, int iDamage );
     CMsgUnitDamage( CMsgCompUnitDamageElem* pElem );
 
@@ -541,12 +565,13 @@ class CMsgUnitDamage : public CNetCmd
 class CMsgUnitSetDamage : public CNetCmd
 {
   public:
-    CMsgUnitSetDamage( ): CNetCmd( unit_set_damage ) {}
-    CMsgUnitSetDamage( DWORD dwDam, DWORD dwShoot, int iDam ): CNetCmd( unit_set_damage )
+    CMsgUnitSetDamage( )
+        : CNetCmd( unit_set_damage ), m_dwIDDamage( ), m_dwIDShoot( ), m_iDamageLevel( )
     {
-        m_dwIDDamage   = dwDam;
-        m_dwIDShoot    = dwShoot;
-        m_iDamageLevel = iDam;
+    }
+    CMsgUnitSetDamage( DWORD dwDam, DWORD dwShoot, int iDam )
+        : CNetCmd( unit_set_damage ), m_dwIDDamage( dwDam ), m_dwIDShoot( dwShoot ), m_iDamageLevel( iDam )
+    {
     }
     CMsgUnitSetDamage( CMsgCompUnitDamageElem* pElem );
 
@@ -629,7 +654,7 @@ class CMsgBuildBldg : public _CMsgBldg
 class CMsgBuildVeh : public CNetCmd
 {
   public:
-    CMsgBuildVeh( ): CNetCmd( build_veh ) {}
+    CMsgBuildVeh( ): CNetCmd( build_veh ), m_dwID( ), m_iVehType( ), m_iNum( ) {}
     CMsgBuildVeh( CBuilding const* pBldg, int iVehType, int iNum = 1 );
 
     DWORD m_dwID;      // ID of factory
@@ -707,7 +732,7 @@ class CMsgVehGoto : public _CMsgVehGo
 class CMsgTransMat : public CNetCmd
 {
   public:
-    CMsgTransMat( ): CNetCmd( trans_mat ) {}
+    CMsgTransMat( ): CNetCmd( trans_mat ), m_dwIDSrc( ), m_dwIDDest( ), m_aiMat( ) {}
     CMsgTransMat( CUnit const* pSrc, CUnit const* pDest );
 
     DWORD m_dwIDSrc;                           // ID of unit giving up materials
@@ -724,7 +749,7 @@ class CMsgTransMat : public CNetCmd
 class CMsgUnitControl : public CNetCmd
 {
   public:
-    CMsgUnitControl( ): CNetCmd( unit_control ) {}
+    CMsgUnitControl( ): CNetCmd( unit_control ), m_dwID( ), m_cCmd( ) {}
     enum
     {
         cancel,
@@ -746,7 +771,7 @@ class CMsgUnitControl : public CNetCmd
 class CMsgUnitRepair : public CNetCmd
 {
   public:
-    CMsgUnitRepair( ): CNetCmd( unit_repair ) {}
+    CMsgUnitRepair( ): CNetCmd( unit_repair ), m_dwID( ), m_iPlyr( ), m_iRepair( ), m_iDamageLevel( ) {}
     CMsgUnitRepair( CUnit const* pUnit, int iRepair );
 
     void ToSetRepair( ) { m_bMsg = unit_set_repair; }
@@ -766,7 +791,7 @@ class CMsgUnitRepair : public CNetCmd
 class CMsgDestroyUnit : public CNetCmd
 {
   public:
-    CMsgDestroyUnit( ): CNetCmd( destroy_unit ) {}
+    CMsgDestroyUnit( ): CNetCmd( destroy_unit ), m_dwID( ) {}
     CMsgDestroyUnit( CUnit const* pUnit );
 
     DWORD m_dwID;  // ID of unit
@@ -1019,7 +1044,7 @@ class CMsgDeployIt : public CNetCmd
 class CMsgPlyrDying : public CNetCmd
 {
   public:
-    CMsgPlyrDying( ): CNetCmd( plyr_dying ) {}
+    CMsgPlyrDying( ): CNetCmd( plyr_dying ), m_iPlyrNum( ) {}
     CMsgPlyrDying( CPlayer const* pPlyr );
 
     int m_iPlyrNum;
@@ -1029,7 +1054,7 @@ class CMsgPlyrDying : public CNetCmd
 class CMsgPlyrDead : public CNetCmd
 {
   public:
-    CMsgPlyrDead( ): CNetCmd( plyr_dead ) {}
+    CMsgPlyrDead( ): CNetCmd( plyr_dead ), m_pPlyr( ) {}
     CMsgPlyrDead( CPlayer* pPlyr );
 
     CPlayer* m_pPlyr;
@@ -1039,11 +1064,9 @@ class CMsgPlyrDead : public CNetCmd
 class CMsgRsrch : public CNetCmd
 {
   public:
-    CMsgRsrch( ): CNetCmd( set_rsrch ) {}
-    CMsgRsrch( int iPlyr, int iTopic ): CNetCmd( set_rsrch )
+    CMsgRsrch( ): CNetCmd( set_rsrch ), m_iPlyrNum( ), m_iTopic( ) {}
+    CMsgRsrch( int iPlyr, int iTopic ): CNetCmd( set_rsrch ), m_iPlyrNum( iPlyr ), m_iTopic( iTopic )
     {
-        m_iPlyrNum = iPlyr;
-        m_iTopic   = iTopic;
     }
 
     int m_iPlyrNum;
@@ -1054,7 +1077,7 @@ class CMsgRsrch : public CNetCmd
 class CMsgLoadCarrier : public CNetCmd
 {
   public:
-    CMsgLoadCarrier( ): CNetCmd( load_carrier ) {}
+    CMsgLoadCarrier( ): CNetCmd( load_carrier ), m_dwIDCargo( ), m_dwIDCarrier( ) {}
     CMsgLoadCarrier( CVehicle const* pCargo, CVehicle const* pCarrier );
 
     DWORD m_dwIDCargo;    // unit to carry
@@ -1065,7 +1088,7 @@ class CMsgLoadCarrier : public CNetCmd
 class CMsgUnloadCarrier : public CNetCmd
 {
   public:
-    CMsgUnloadCarrier( ): CNetCmd( unload_carrier ) {}
+    CMsgUnloadCarrier( ): CNetCmd( unload_carrier ), m_dwID( ) {}
     CMsgUnloadCarrier( CVehicle const* pVeh );
 
     DWORD m_dwID;  // unit carrying it

--- a/src/cdf/CMakeLists.txt
+++ b/src/cdf/CMakeLists.txt
@@ -15,8 +15,8 @@ add_executable(cdf ${cdf_sources})
 #        "$<$<CONFIG:DEBUG>:$<BUILD_INTERFACE:/GX>"
 #        )
 target_compile_options(cdf PRIVATE
-    $<$<CONFIG:RELEASE>:/GX;/Zi;/O2;/Ob2>
-    $<$<CONFIG:DEBUG>:/GX>
+    $<$<CONFIG:RELEASE>:/EHsc;/Zi;/O2;/Ob2>
+    $<$<CONFIG:DEBUG>:/EHsc>
 )
 #message("CMAKE_CXX_FLAGS: ${CMAKE_CXX_FLAGS}")
 

--- a/tools/compress/CMakeLists.txt
+++ b/tools/compress/CMakeLists.txt
@@ -13,8 +13,8 @@ set(compit_sources
 add_executable(compit ${compit_sources})
 
 target_compile_options(compit INTERFACE
-        "$<$<CONFIG:RELEASE>:$<BUILD_INTERFACE:/GX;/Zi;/O2;/Ob2>"
-        "$<$<CONFIG:DEBUG>:$<BUILD_INTERFACE:/GX>"
+        "$<$<CONFIG:RELEASE>:$<BUILD_INTERFACE:/EHsc;/Zi;/O2;/Ob2>"
+        "$<$<CONFIG:DEBUG>:$<BUILD_INTERFACE:/EHsc>"
         )
 
 #message("CMAKE_CXX_FLAGS: ${CMAKE_CXX_FLAGS}")

--- a/tools/makeriff/CMakeLists.txt
+++ b/tools/makeriff/CMakeLists.txt
@@ -14,8 +14,8 @@ set(makeriff_sources
 add_executable(makeriff ${makeriff_sources})
 
 target_compile_options(makeriff INTERFACE
-        "$<$<CONFIG:RELEASE>:$<BUILD_INTERFACE:/MD;/GX;/Zi;/O2;/Ob2>"
-        "$<$<CONFIG:DEBUG>:$<BUILD_INTERFACE:/MD;/GX>"
+        "$<$<CONFIG:RELEASE>:$<BUILD_INTERFACE:/MD;/EHsc;/Zi;/O2;/Ob2>"
+        "$<$<CONFIG:DEBUG>:$<BUILD_INTERFACE:/MD;/EHsc>"
         )
 
 message("CMAKE_CXX_FLAGS: ${CMAKE_CXX_FLAGS}")

--- a/tools/sprite/CMakeLists.txt
+++ b/tools/sprite/CMakeLists.txt
@@ -46,8 +46,8 @@ set(sprite_sources
 add_executable(sprite WIN32 ${sprite_sources})
 
 target_compile_options(sprite INTERFACE
-        "$<$<CONFIG:RELEASE>:$<BUILD_INTERFACE:/MD;/GX;/Zi;/O2;/Ob2;/EHsc>"
-        "$<$<CONFIG:DEBUG>:$<BUILD_INTERFACE:/MD;/GX;/EHsc>"
+        "$<$<CONFIG:RELEASE>:$<BUILD_INTERFACE:/MD;/Zi;/O2;/Ob2;/EHsc>"
+        "$<$<CONFIG:DEBUG>:$<BUILD_INTERFACE:/MD;/EHsc>"
         )
 
 message("CMAKE_CXX_FLAGS: ${CMAKE_CXX_FLAGS}")

--- a/tools/sprite/stucki.h
+++ b/tools/sprite/stucki.h
@@ -12,8 +12,8 @@
 //  Should be nested class when supported by compiler.
 struct sortedColor
 {
-	RGBColor 	color;
-	byte		originalIndex;
+    RGBColor color = {};
+    byte     originalIndex = {};
 };
 
 class StuckiDither : public Dither
@@ -32,7 +32,7 @@ class StuckiDither : public Dither
 
 		//  Default ctor because compiler can't 
 		//  generate one.  Why not?
-		StuckiDither()	{}
+      StuckiDither( ): aOriginalPalette( ), aSortedPalette( ), palSize( ), redLookup( ) {}
 
 		virtual bool Init( const RGBColor *pPalette, int palSize );
 		virtual Image *DitherImage( const Image *pOriginalImage );

--- a/tools/vdmplay/ISERVE/CMakeLists.txt
+++ b/tools/vdmplay/ISERVE/CMakeLists.txt
@@ -46,8 +46,8 @@ target_compile_definitions(iserve PRIVATE
 )
 
 target_compile_options(iserve PRIVATE
-    $<$<CONFIG:Debug>:/MD /W3 /GX /Zi /Od>
-    $<$<CONFIG:Release>:/MD /W3 /GX /O2>
+    $<$<CONFIG:Debug>:/MD /W3 /EHsc /Zi /Od>
+    $<$<CONFIG:Release>:/MD /W3 /EHsc /O2>
 )
 
 target_link_options(iserve PRIVATE

--- a/tools/vdmplay/ISERVE/ISERVDLG.CPP
+++ b/tools/vdmplay/ISERVE/ISERVDLG.CPP
@@ -299,7 +299,7 @@ void CIserveDlg::OnAbout ()
 CString CIserveDlg::GetAddressString(LPCVPNETADDRESS a)
 {
 
-	char buf[256];
+	char buf[256] = {};
 	buf[0] = 0;
 
 	vpGetAddressString(m_vpH, a, buf, sizeof(buf));
@@ -355,7 +355,7 @@ LONG CIserveDlg::OnVpNotify(WPARAM w, LPARAM l)
 CString CIserveDlg::GetSessionData(LPCVPSESSIONINFO info)
 {
 	CString sData;
-	char sessionAddress[256];
+    char    sessionAddress[256] = {};
 
 	sessionAddress[0] = 0;
 	vpGetAddressString(m_vpH, &info->sessionId, sessionAddress, sizeof(sessionAddress));

--- a/tools/vdmplay/ISERVE/ISERVDLG.CPP
+++ b/tools/vdmplay/ISERVE/ISERVDLG.CPP
@@ -83,7 +83,7 @@ CIserveDlg::CIserveDlg(CWnd* pParent /*=NULL*/)
 	CWinApp* app = AfxGetApp();
 	m_hIcon = app->LoadIcon(IDR_MAINFRAME);
 
-	if (!stricmp(app->m_lpCmdLine, "/IPX"))
+	if (!_stricmp(app->m_lpCmdLine, "/IPX"))
 		m_protocol = VPT_IPX;
 
 }
@@ -148,7 +148,7 @@ BOOL CIserveDlg::OnInitDialog()
 			
 	if (iSocket != -1)
 	{
-		itoa (iSocket, m_strSocket.GetBuffer (40), 10);
+		_itoa (iSocket, m_strSocket.GetBuffer (40), 10);
 		m_strSocket.ReleaseBuffer (-1);
 		UpdateData (FALSE);
 	}
@@ -199,9 +199,10 @@ void CIserveDlg::FixStationName()
 	if (m_protocol == VPT_TCP)
 	{
 		CString addr = m_strAddr.SpanExcluding(":");
-		DWORD tcpAddr = inet_addr(addr);
+		DWORD tcpAddr = inet_addr(addr); // TODO: replace with inet_pton see: https://learn.microsoft.com/en-us/windows/win32/api/ws2tcpip/nf-ws2tcpip-inet_pton
 
-		hostent* he = gethostbyaddr((LPSTR) &tcpAddr, sizeof(tcpAddr), PF_INET);
+		hostent* he = gethostbyaddr((LPSTR) &tcpAddr, sizeof(tcpAddr), PF_INET); // TODO: replace with getnameinfo() or GetNameInfoW()
+                                                                                          // see: https://learn.microsoft.com/en-us/windows/win32/api/ws2tcpip/nf-ws2tcpip-getnameinfo
 	
 		if (he)
 			m_strName = he->h_name;
@@ -407,10 +408,10 @@ void CIserveDlg::UpdateCaption ()
 	}
 
 	CString sTitle;
-	sTitle.LoadString (m_vpH ? IDS_TITLE : IDS_TITLE_WHEN_OFF);
+	(void)sTitle.LoadString (m_vpH ? IDS_TITLE : IDS_TITLE_WHEN_OFF);
 
 	char sBuf[80];
-	sprintf (sBuf, sTitle, m_ServerList.GetCount ());
+	sprintf_s (sBuf, sTitle, m_ServerList.GetCount ());
 	SetWindowText(sBuf);
 }
 
@@ -452,7 +453,7 @@ void CDlgSocket::OnOK()
 	
 	UpdateData (TRUE);
 	char sBuf[20];
-	itoa (m_iSocket, sBuf, 10);
+	_itoa (m_iSocket, sBuf, 10);
 
 	const char* protoStr;
 

--- a/tools/vdmplay/ISERVE/ISERVE.CPP
+++ b/tools/vdmplay/ISERVE/ISERVE.CPP
@@ -45,7 +45,6 @@ BOOL CIserveApp::InitInstance()
 	//  of your final executable, you should remove from the following
 	//  the specific initialization routines you do not need.
 
-	Enable3dControls();
 	LoadStdProfileSettings();  // Load standard INI file options (including MRU)
 
 	CIserveDlg dlg;

--- a/tools/vdmplay/advdlg.cpp
+++ b/tools/vdmplay/advdlg.cpp
@@ -95,7 +95,8 @@ void FillPortCombo(CComboBox &aComboBox) {
         char sBuf[10];
         strcpy(sBuf, "COM");
         itoa(iPort, &sBuf[3], 10);
-        HANDLE dev = CreateFile(sBuf, GENERIC_READ | GENERIC_WRITE, 0, NULL,
+        HANDLE dev = INVALID_HANDLE_VALUE;
+        dev = CreateFile(sBuf, GENERIC_READ | GENERIC_WRITE, 0, NULL,
                                 OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL | FILE_FLAG_OVERLAPPED, NULL);
         if (dev != INVALID_HANDLE_VALUE) {
             CloseHandle(dev);

--- a/tools/vdmplay/advdlg.cpp
+++ b/tools/vdmplay/advdlg.cpp
@@ -637,9 +637,9 @@ BOOL CAdvNbDlg::OnInitDialog() {
     m_stationName = FetchString("Netbios", "StationName");
     m_lanaStr = FetchString("Netbios", "Lana");
 
-    NCB ncb;
-    LANA_ENUM lEnum;
-    UCHAR ret;
+    NCB       ncb   = {};
+    LANA_ENUM lEnum = {};
+    UCHAR     ret   = {};
 
     memset(&ncb, 0, sizeof(ncb));
 

--- a/tools/vdmplay/comstatd.cpp
+++ b/tools/vdmplay/comstatd.cpp
@@ -93,7 +93,7 @@ void CComStatDlg::ShowStatus(UINT id)
  wsprintf(buf, fmt, (LPCSTR) m_number);
  SetDlgItemText(m_hWnd, IDC_COMM_STATUS, buf);
 #else
- m_commStat.LoadString(id);
+ (void)m_commStat.LoadString(id);
  UpdateData(FALSE);
 #endif
 
@@ -118,9 +118,15 @@ void CComStatDlg::ShowTrace(LPCSTR p, UINT size)
 #else
  char* tmp = (char*) malloc(size+1);
 #endif
- 
- memcpy(tmp, p, size);
- tmp[size] = 0;
+ if ( tmp != 0 )
+ {
+     memcpy(tmp, p, size);
+     tmp[size] = 0;
+ }
+ else
+ {
+     return;
+ }
 #ifndef NOMFC
  UINT i = m_commTrace.AddString(tmp);
  m_commTrace.SetTopIndex(i);

--- a/tools/vdmplay/datagram.h
+++ b/tools/vdmplay/datagram.h
@@ -16,9 +16,10 @@ public:
     WORD m_chksum;
 
 
-    Datagram() : m_size(0), m_data(NULL), m_offset(0) {}
+    Datagram( ): m_size( 0 ), m_bufSize( 0 ), m_data( NULL ), m_offset( 0 ), m_time( 0 ), m_seq( 0 ), m_chksum( 0 ) {}
 
-    Datagram(WORD bSize) : m_bufSize(bSize), m_size(0), m_offset(0) {
+    Datagram( WORD bSize ): m_bufSize( bSize ), m_size( 0 ), m_offset( 0 ), m_time( 0 ), m_seq( 0 ), m_chksum( 0 )
+    {
 #ifdef USE_VPMEM
         m_data = (LPSTR) vpAllocMem(bSize);
 #else
@@ -26,10 +27,11 @@ public:
 #endif
     }
 
-    Datagram(LPVOID data, WORD size) : m_size(size), m_offset(0) {
+    Datagram( LPVOID data, WORD size ): m_size( size ), m_bufSize( 0 ), m_data( NULL ), m_offset( 0 ), m_chksum( 0 )
+    {
         VPASSERT(data);
         VPASSERT(size);
-        m_time = GetCurrentTime();
+        m_time = GetCurrentTime(); // TODO: Consider switching to GetTickCount64()
 
 #ifdef USE_VPMEM
         m_data = (LPSTR) vpAllocMem(m_size);
@@ -45,7 +47,7 @@ public:
         VPASSERT(data);
         VPASSERT(size);
 
-        m_time = GetCurrentTime();
+        m_time = GetCurrentTime(); // TODO: Consider switching to GetTickCount64()
 
         if (pfx)
             m_size += sizeof(WORD);

--- a/tools/vdmplay/tdlog.h
+++ b/tools/vdmplay/tdlog.h
@@ -6,7 +6,7 @@ class CTDLogger
 {
  
 public:
- CTDLogger()  { m_time = GetCurrentTime(); }
+    CTDLogger( ): m_buf( ) { m_time = GetCurrentTime( ); } // TODO: Consider switching to GetTickCount64()
  virtual ~CTDLogger() { }
 
  virtual void Write(LPCSTR) = 0;

--- a/windward/wind22/include/dibwnd.h
+++ b/windward/wind22/include/dibwnd.h
@@ -118,7 +118,7 @@ protected:
     void CoalesceRects( CRect arect[], int& nCount );
 
 #ifdef OPTIMIZE_BLIT_ORDER
-    void CDirtyRects::SortRectsByPosition( CRect arect[], int nCount );
+    void SortRectsByPosition( CRect arect[], int nCount );
 #endif
     void AddRect( CRect const* prect, CRect arect[], int& );
 

--- a/windward/wind22/src/scanlist.cpp
+++ b/windward/wind22/src/scanlist.cpp
@@ -96,6 +96,7 @@ void ScanList::ScanPoly( CPoint const apt[],  // Array of points in clockwise or
     //--------------------------------------------------------------------------
 // ScanList::ScanPoly
 //--------------------------------------------------------------------------
+#pragma warning( disable : 4731 5073 )
 void
 ScanList::ScanPolyOld(
     CPoint const apt[], // Array of points in clockwise order
@@ -266,6 +267,7 @@ ScanList::ScanPolyOld(
 
     ASSERT_STRICT_VALID( this );
 }
+#pragma warning( default : 4731 5073 )
 
 
 //--------------------------------------------------------------------------
@@ -397,7 +399,7 @@ void ScanList::ScanPolyNew( CPoint const apt[], int iCount )
 //--------------------------------------------------------------------------
 // ScanList::ScanPolyFixed
 //--------------------------------------------------------------------------
-
+#pragma warning( disable : 4731 5073 )
 void
 ScanList::ScanPolyFixedOld(
     CPoint const apt[],  // Array of points in clockwise order
@@ -554,9 +556,9 @@ ScanList::ScanPolyFixedOld(
 
     ASSERT_STRICT_VALID( this );
 }
+#pragma warning( default : 4731 5073 )
 
-
-    //--------------------------------------------------------------------------
+//--------------------------------------------------------------------------
 // ScanList::ScanPolyFixed
 //--------------------------------------------------------------------------
 void ScanList::ScanPolyFixed(CPoint const apt[],  // Array of points in clockwise order


### PR DESCRIPTION
Most of the changes are initializing variables/members. However there are some other minor changes. I disabled ASAN warnings for some of the inline assembly, switched other projects to use the `/EHsc` flag instead of `/GX`, removed the class name from SortRectsByPosition, renamed posix functions to the ISO standard names `stricmp` -> `_stricmp`, and added explicit void casts for unused return values. Working towards #11, this is the first bit of code cleanup. Ideally it would be good to be able to compile with `/W4 /WX`.